### PR TITLE
Add node-setup image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ build:
 	> '.build_state'
 	$(call build-image,./base/ubuntu,$(REPO):base-ubuntu,)
 	$(call build-image,./golang/1.18,$(REPO):golang-1.18,$(REPO):base-ubuntu)
+	$(call build-image,./node-setup,$(REPO):node-setup,$(REPO):base-ubuntu)
 .PHONY: build
 
 publish-last-build:

--- a/node-setup/Dockerfile
+++ b/node-setup/Dockerfile
@@ -1,0 +1,6 @@
+FROM to-be-replaced-by-local-ref/base:ubuntu
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends xfsprogs && \
+    apt-get clean  && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR introduces a Dockerfile and necessary Makefile changes for creating `node-setup` image. The image installs `xfsprogs` package on top of `base-ubuntu` image.

The image is required for the setup of local volumes in `scylla-operator`'s CI (https://github.com/scylladb/scylla-operator/pull/979).