### PR TITLE
Update Golang to 1.18.5

### DIFF
--- a/golang/1.18/Dockerfile
+++ b/golang/1.18/Dockerfile
@@ -7,4 +7,5 @@ ENV PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git make tar gzip && \
     apt-get clean && \
-    curl --fail --retry 5 -L https://go.dev/dl/go1.18.1.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+    rm -rf /var/lib/apt/lists/* && \
+    curl --fail --retry 5 -L https://go.dev/dl/go1.18.5.linux-amd64.tar.gz | tar -C /usr/local -xzf -


### PR DESCRIPTION
Updates golang-1.18 to 1.18.5 and cleans up after apt. 