### PR TITLE
Add Golang 1.19 and verify checksums

### DIFF
--- a/golang/1.18/Dockerfile
+++ b/golang/1.18/Dockerfile
@@ -10,5 +10,5 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends git make tar gzip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    /tmp/download-file.sh https://go.dev/dl/go1.18.5.linux-amd64.tar.gz 'c83a94b12a762f458d38e1bcd41612dc53960c16baa02a58a7a86cf2c19542f4b5255562dc83d3cdd5cdbfb4678db3c4cfcf8be6e020347f5d56f79bba0b1f1c' | tar -C /usr/local -xzf - && \
+    /tmp/download-file.sh https://go.dev/dl/go1.18.6.linux-amd64.tar.gz 'd71abdf8a3639207185b373697888ec5a95b282ac798ce1a112ac6edcd41c3f331609560b6915336b316018b22e8fff4df1a3cb12d075bbc5492c869013f7f59' | tar -C /usr/local -xzf - && \
     rm -rf /tmp/

--- a/golang/1.18/Dockerfile
+++ b/golang/1.18/Dockerfile
@@ -4,8 +4,11 @@ ENV GOPATH=/go \
     GOROOT=/usr/local/go
 ENV PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin
 
+COPY ./download-file.sh /tmp/
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git make tar gzip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    curl --fail --retry 5 -L https://go.dev/dl/go1.18.5.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+    /tmp/download-file.sh https://go.dev/dl/go1.18.5.linux-amd64.tar.gz 'c83a94b12a762f458d38e1bcd41612dc53960c16baa02a58a7a86cf2c19542f4b5255562dc83d3cdd5cdbfb4678db3c4cfcf8be6e020347f5d56f79bba0b1f1c' | tar -C /usr/local -xzf - && \
+    rm -rf /tmp/

--- a/golang/1.18/download-file.sh
+++ b/golang/1.18/download-file.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euExo pipefail
+shopt -s inherit_errexit
+
+if [ "$#" != "2" ]; then
+	echo "Usage: $0 <URL> <SHA>" > /dev/stderr
+	exit 1
+fi
+
+url="$1"
+sha="$2"
+
+tmp="$( mktemp )"
+trap 'rm -f ${tmp}' EXIT
+
+curl --fail --retry 5 -L "${url}" > "${tmp}"
+
+sha512sum -c <( echo "${sha}  ${tmp}" ) > /dev/stderr
+
+cat "${tmp}"

--- a/golang/1.19/Dockerfile
+++ b/golang/1.19/Dockerfile
@@ -1,0 +1,14 @@
+FROM to-be-replaced-by-local-ref/base:ubuntu
+
+ENV GOPATH=/go \
+    GOROOT=/usr/local/go
+ENV PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin
+
+COPY ./download-file.sh /tmp/
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git make tar gzip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    /tmp/download-file.sh https://go.dev/dl/go1.19.1.linux-amd64.tar.gz 'a69153393a2eaf1c2b77f5a4bafe6a2fb36368c6856d79bd697472af71d925fc62c58e6b8fe75adf143b0462da2ed9e68d0fcd0328cde091be70d745b92814aa' | tar -C /usr/local -xzf - && \
+    rm -rf /tmp/

--- a/golang/1.19/download-file.sh
+++ b/golang/1.19/download-file.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euExo pipefail
+shopt -s inherit_errexit
+
+if [ "$#" != "2" ]; then
+	echo "Usage: $0 <URL> <SHA>" > /dev/stderr
+	exit 1
+fi
+
+url="$1"
+sha="$2"
+
+tmp="$( mktemp )"
+trap 'rm -f ${tmp}' EXIT
+
+curl --fail --retry 5 -L "${url}" > "${tmp}"
+
+sha512sum -c <( echo "${sha}  ${tmp}" ) > /dev/stderr
+
+cat "${tmp}"


### PR DESCRIPTION
This adds:
- Golang 1.19.1 - (it's time)
- Checksum verification (security)
- Bumps golang 1.18 from 1.18.5 to 1.18.6 (security)