### PR TITLE
Build and publish Golang 1.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ build:
 	> '.build_state'
 	$(call build-image,./base/ubuntu,$(REPO):base-ubuntu,)
 	$(call build-image,./golang/1.18,$(REPO):golang-1.18,$(REPO):base-ubuntu)
+	$(call build-image,./golang/1.19,$(REPO):golang-1.19,$(REPO):base-ubuntu)
 	$(call build-image,./node-setup,$(REPO):node-setup,$(REPO):base-ubuntu)
 .PHONY: build
 


### PR DESCRIPTION
Followup to https://github.com/scylladb/scylla-operator-images/pull/3 to build and publish the Golang 1.19 image.