### PR TITLE
Add Go 1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ build:
 	$(call build-image,./base/ubuntu/22.04,$(REPO):base-ubuntu-22.04,)
 	$(call build-image,./golang/1.18,$(REPO):golang-1.18,$(REPO):base-ubuntu-22.04)
 	$(call build-image,./golang/1.19,$(REPO):golang-1.19,$(REPO):base-ubuntu-22.04)
+	$(call build-image,./golang/1.20,$(REPO):golang-1.20,$(REPO):base-ubuntu-22.04)
 	$(call build-image,./node-setup,$(REPO):node-setup,$(REPO):base-ubuntu-22.04)
 .PHONY: build
 

--- a/golang/1.20/Dockerfile
+++ b/golang/1.20/Dockerfile
@@ -1,0 +1,14 @@
+FROM to-be-replaced-by-local-ref/base:ubuntu-22.04
+
+ENV GOPATH=/go \
+    GOROOT=/usr/local/go
+ENV PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin
+
+COPY ./download-file.sh /tmp/
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git make tar gzip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    /tmp/download-file.sh https://go.dev/dl/go1.20.2.linux-amd64.tar.gz 'bd196b7bb89548d6cf7a3a23f3709aa9695f02fcac979b31f47a061145004a71da5791696486e26a3b589620b15a2a2fdc8c3540649d73c7fa866e2b6bdbc7f9' | tar -C /usr/local -xzf - && \
+    rm -rf /tmp/*

--- a/golang/1.20/download-file.sh
+++ b/golang/1.20/download-file.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euExo pipefail
+shopt -s inherit_errexit
+
+if [ "$#" != "2" ]; then
+	echo "Usage: $0 <URL> <SHA>" > /dev/stderr
+	exit 1
+fi
+
+url="$1"
+sha="$2"
+
+tmp="$( mktemp )"
+trap 'rm -f ${tmp}' EXIT
+
+curl --fail --retry 5 -L "${url}" > "${tmp}"
+
+sha512sum -c <( echo "${sha}  ${tmp}" ) > /dev/stderr
+
+cat "${tmp}"


### PR DESCRIPTION
This PR adds Go 1.20.2 image pipeline.

**Resolves**: https://github.com/scylladb/scylla-operator-images/issues/10