### PR TITLE
Add yq to golang images for build tooling

### DIFF
--- a/golang/1.18/Dockerfile
+++ b/golang/1.18/Dockerfile
@@ -11,4 +11,5 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     /tmp/download-file.sh https://go.dev/dl/go1.18.10.linux-amd64.tar.gz '2f1986ae1a95f1e2e735abdf2240770210482215c03293322ce9d3cb7b5c7b2904943827154d048771b00fa95d9b5e659d8077873dea0352d7d8cca8880ce204' | tar -C /usr/local -xzf - && \
+    go install github.com/mikefarah/yq/v4@v4.34.1 && \
     rm -rf /tmp/*

--- a/golang/1.19/Dockerfile
+++ b/golang/1.19/Dockerfile
@@ -11,4 +11,5 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     /tmp/download-file.sh https://go.dev/dl/go1.19.8.linux-amd64.tar.gz '469ff06d6b86d201bcf01abbb6eed6897091afed2fd47726d90589424e4abd9a561cc24c8c2a5ce3a172a8905bfcdb35e32aef4a72ad380584f549fd20cb1d42' | tar -C /usr/local -xzf - && \
+    go install github.com/mikefarah/yq/v4@v4.34.1 && \
     rm -rf /tmp/*

--- a/golang/1.20/Dockerfile
+++ b/golang/1.20/Dockerfile
@@ -11,4 +11,5 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     /tmp/download-file.sh https://go.dev/dl/go1.20.3.linux-amd64.tar.gz 'b6e74b9b0bf03371e746b1b579235665a692425847b685f1a862345a5858329ec24e184db4ddbd2fd617e22df4c48d3e95fe7ba79b19d737c6d6afa63a129773' | tar -C /usr/local -xzf - && \
+    go install github.com/mikefarah/yq/v4@v4.34.1 && \
     rm -rf /tmp/*


### PR DESCRIPTION
When executing build scripts, it's helpful to have yq around. Having extra tools in golang image is fine as this is not a production runtime.