### PR TITLE
Add kube-tools for CI jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ build:
 	$(call build-image,./golang/1.18,$(REPO):golang-1.18,$(REPO):base-ubuntu-22.04)
 	$(call build-image,./golang/1.19,$(REPO):golang-1.19,$(REPO):base-ubuntu-22.04)
 	$(call build-image,./golang/1.20,$(REPO):golang-1.20,$(REPO):base-ubuntu-22.04)
+	$(call build-image,./kube-tools/latest,$(REPO):kube-tools,$(REPO):golang-1.20)
 	$(call build-image,./node-setup,$(REPO):node-setup,$(REPO):base-ubuntu-22.04)
 .PHONY: build
 

--- a/kube-tools/latest/Dockerfile
+++ b/kube-tools/latest/Dockerfile
@@ -1,0 +1,14 @@
+FROM to-be-replaced-by-local-ref/golang:1.20
+
+RUN set -euExo pipefail && shopt -s inherit_errexit && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends rsync && \
+    apt-get clean && \
+    mkdir -p /go/src/k8s.io/ && \
+    cd /go/src/k8s.io/ && \
+    git clone --depth=1 --branch v1.27.3 https://github.com/kubernetes/kubernetes.git && \
+    cd ./kubernetes && \
+    make WHAT=cmd/kubectl && \
+    mv /go/src/k8s.io/kubernetes/_output/bin/kubectl /usr/bin/ && \
+    rm -rf /go/src/k8s.io/ && \
+    rm -rf /tmp/*


### PR DESCRIPTION
This PR add a rolling image that contains various tools we need for container based CI. Say, to deploy an app, you need `kubectl apply` and `yq`. We can later extend it with others that are needed.

This is a special case of a rolling image where we are in control and versioning a set of tools would have more downsides then the stability benefit.