### PR TITLE
Add podman to kube-tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ build:
 	$(call build-image,./golang/1.18,$(REPO):golang-1.18,$(REPO):base-ubuntu-22.04)
 	$(call build-image,./golang/1.19,$(REPO):golang-1.19,$(REPO):base-ubuntu-22.04)
 	$(call build-image,./golang/1.20,$(REPO):golang-1.20,$(REPO):base-ubuntu-22.04)
-	$(call build-image,./kube-tools/latest,$(REPO):kube-tools,$(REPO):golang-1.20)
+	$(call build-image,./kube-tools/latest,$(REPO):kube-tools,)
 	$(call build-image,./node-setup,$(REPO):node-setup,$(REPO):base-ubuntu-22.04)
 .PHONY: build
 

--- a/kube-tools/latest/Dockerfile
+++ b/kube-tools/latest/Dockerfile
@@ -1,9 +1,9 @@
-FROM to-be-replaced-by-local-ref/golang:1.20
+FROM quay.io/podman/stable:v4.5
 
 RUN set -euExo pipefail && shopt -s inherit_errexit && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends rsync && \
-    apt-get clean && \
+    dnf install -y rsync git make tar gzip golang && \
+    dnf clean all && \
+    go install github.com/mikefarah/yq/v4@v4.34.1 && \
     mkdir -p /go/src/k8s.io/ && \
     cd /go/src/k8s.io/ && \
     git clone --depth=1 --branch v1.27.3 https://github.com/kubernetes/kubernetes.git && \


### PR DESCRIPTION
To be able to run e2e suite from an image locally, we need podman available. It's easier to base this image on the most complex component (requires config to run inside containers), and add the easier ones.

This is using fedora:38 as a base.