### PR TITLE
Bump podman base in kube-tools image to 4.6

### DIFF
--- a/kube-tools/latest/Dockerfile
+++ b/kube-tools/latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/podman/stable:v4.5
+FROM quay.io/podman/stable:v4.6
 
 RUN set -euExo pipefail && shopt -s inherit_errexit && \
     dnf install -y rsync git make tar gzip golang skopeo && \


### PR DESCRIPTION
Podman 4.5 is currently unavailable due to:
https://github.com/containers/podman/discussions/19796