### PR TITLE
Install packages required by unit tests in golang image

### DIFF
--- a/golang/1.20/Dockerfile
+++ b/golang/1.20/Dockerfile
@@ -7,7 +7,7 @@ ENV PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin
 COPY ./download-file.sh /tmp/
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git make tar gzip && \
+    apt-get install -y --no-install-recommends git make tar gzip gcc g++ libc6-dev dbus-x11 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     /tmp/download-file.sh https://go.dev/dl/go1.20.3.linux-amd64.tar.gz 'b6e74b9b0bf03371e746b1b579235665a692425847b685f1a862345a5858329ec24e184db4ddbd2fd617e22df4c48d3e95fe7ba79b19d737c6d6afa63a129773' | tar -C /usr/local -xzf - && \


### PR DESCRIPTION
`gcc`, `g++`, `libc6-dev` are required by cgo which is required for running race detector in tests.
`dbus-x11` is required by our tests to run `dbus-launch`.