### PR TITLE
Retry all errors when downloading Golang archives

### DIFF
--- a/golang/1.18/download-file.sh
+++ b/golang/1.18/download-file.sh
@@ -14,7 +14,7 @@ sha="$2"
 tmp="$( mktemp )"
 trap 'rm -f ${tmp}' EXIT
 
-curl --fail --retry 5 -L "${url}" > "${tmp}"
+curl --fail --retry 5 --retry-all-errors -L "${url}" > "${tmp}"
 
 sha512sum -c <( echo "${sha}  ${tmp}" ) > /dev/stderr
 

--- a/golang/1.19/download-file.sh
+++ b/golang/1.19/download-file.sh
@@ -14,7 +14,7 @@ sha="$2"
 tmp="$( mktemp )"
 trap 'rm -f ${tmp}' EXIT
 
-curl --fail --retry 5 -L "${url}" > "${tmp}"
+curl --fail --retry 5 --retry-all-errors -L "${url}" > "${tmp}"
 
 sha512sum -c <( echo "${sha}  ${tmp}" ) > /dev/stderr
 

--- a/golang/1.20/download-file.sh
+++ b/golang/1.20/download-file.sh
@@ -14,7 +14,7 @@ sha="$2"
 tmp="$( mktemp )"
 trap 'rm -f ${tmp}' EXIT
 
-curl --fail --retry 5 -L "${url}" > "${tmp}"
+curl --fail --retry 5 --retry-all-errors -L "${url}" > "${tmp}"
 
 sha512sum -c <( echo "${sha}  ${tmp}" ) > /dev/stderr
 


### PR DESCRIPTION
To retry SSL connection errors (and others) `curl` needs `--retry-all-errors` flag.