### PR TITLE
Make sure there is no old data on curl retries

### DIFF
--- a/golang/1.20/download-file.sh
+++ b/golang/1.20/download-file.sh
@@ -14,7 +14,7 @@ sha="$2"
 tmp="$( mktemp )"
 trap 'rm -f ${tmp}' EXIT
 
-curl --fail --retry 5 --retry-all-errors -L "${url}" > "${tmp}"
+curl --fail --retry 5 --retry-all-errors -L "${url}" -o "${tmp}"
 
 sha512sum -c <( echo "${sha}  ${tmp}" ) > /dev/stderr
 


### PR DESCRIPTION
When retrying a download far enough output redirection will still have the old data and fail the checksum. Using `-o` instead avoids it.