### PR TITLE
Add govulncheck to golang images

### DIFF
--- a/golang/1.20/Dockerfile
+++ b/golang/1.20/Dockerfile
@@ -16,6 +16,7 @@ RUN apt update && \
         *) exit 42;; \
     esac && \
     /tmp/download-file.sh "https://go.dev/dl/go1.20.3.linux-${architecture}.tar.gz" "${checksum}" | tar -C /usr/local -xzf - && \
+    go install golang.org/x/vuln/cmd/govulncheck@latest && \
     go install github.com/mikefarah/yq/v4@v4.34.1 && \
     go install helm.sh/helm/v3/cmd/helm@1e210a2 && echo "installed helm v3.12.2" && \
     mv "$( go env GOPATH )/bin/yq" /usr/local/bin/ && \

--- a/golang/1.21/Dockerfile
+++ b/golang/1.21/Dockerfile
@@ -16,6 +16,7 @@ RUN apt update && \
         *) exit 42;; \
     esac && \
     /tmp/download-file.sh "https://go.dev/dl/go1.21.3.linux-${architecture}.tar.gz" "${checksum}" | tar -C /usr/local -xzf - && \
+    go install golang.org/x/vuln/cmd/govulncheck@latest && \
     go install github.com/mikefarah/yq/v4@v4.34.1 && \
     go install helm.sh/helm/v3/cmd/helm@1e210a2 && echo "installed helm v3.12.2" && \
     mv "$( go env GOPATH )/bin/yq" /usr/local/bin/ && \


### PR DESCRIPTION
This PRs add govulncheck to your golang image so we can use it for security scanning.

https://go.dev/blog/vuln

/cc @rzetelskik 