### PR TITLE
Add buildah image with git support for parsing repo metadata

### DIFF
--- a/buildah/latest/Dockerfile
+++ b/buildah/latest/Dockerfile
@@ -1,0 +1,5 @@
+FROM quay.io/buildah/stable:v1.33
+
+RUN set -euExo pipefail && shopt -s inherit_errexit && \
+    dnf install -y git && \
+    dnf clean all

--- a/image-spec.csv
+++ b/image-spec.csv
@@ -5,3 +5,4 @@ context_dir,image_tag,from_tag
 ./kube-tools/latest,kube-tools,
 ./node-setup,node-setup,base-ubuntu-22.04
 ./poetry/1.5,poetry-1.5,
+./buildah/latest,buildah,


### PR DESCRIPTION
To add revision label we need `git rev-parse` to find out the current HEAD sha. That's why we need the extended buildah image.

Prerequisite to fixing https://github.com/scylladb/scylla-operator-release/issues/133