### PR TITLE
Disable git owners checks in buildah image for prow

### DIFF
--- a/buildah/latest/Dockerfile
+++ b/buildah/latest/Dockerfile
@@ -2,4 +2,5 @@ FROM quay.io/buildah/stable:v1.33
 
 RUN set -euExo pipefail && shopt -s inherit_errexit && \
     dnf install -y git && \
-    dnf clean all
+    dnf clean all && \
+    git config --global --add safe.directory '*'


### PR DESCRIPTION
On prow the git is created by a sidecar, so the owners are by nature not matching.

`fatal: detected dubious ownership in repository at '/home/prow/go/src/github.com/scylladb/scylla-operator'`

Fixes https://github.com/scylladb/scylla-operator-release/issues/136
