### PR TITLE
Use system config for buildah git config

### DIFF
--- a/buildah/latest/Dockerfile
+++ b/buildah/latest/Dockerfile
@@ -3,4 +3,4 @@ FROM quay.io/buildah/stable:v1.33
 RUN set -euExo pipefail && shopt -s inherit_errexit && \
     dnf install -y git && \
     dnf clean all && \
-    git config --global --add safe.directory '*'
+    git config --system --add safe.directory '*'


### PR DESCRIPTION
Using system config puts it into `/etc/gitconfig` that works everywhere, contrary to `/root/.gitconfig` which won't work unless that's your home dir.


Fixes https://github.com/scylladb/scylla-operator-release/issues/136