### PR TITLE
Always use local Go toolchain

### DIFF
--- a/golang/1.21/Dockerfile
+++ b/golang/1.21/Dockerfile
@@ -1,7 +1,8 @@
 FROM to-be-replaced-by-local-ref/base:ubuntu-22.04
 
 ENV GOPATH=/go \
-    GOROOT=/usr/local/go
+    GOROOT=/usr/local/go \
+    GOTOOLCHAIN=local
 ENV PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin
 
 COPY ./download-file.sh /tmp/

--- a/golang/1.22/Dockerfile
+++ b/golang/1.22/Dockerfile
@@ -1,7 +1,8 @@
 FROM to-be-replaced-by-local-ref/base:ubuntu-22.04
 
 ENV GOPATH=/go \
-    GOROOT=/usr/local/go
+    GOROOT=/usr/local/go \
+    GOTOOLCHAIN=local
 ENV PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin
 
 COPY ./download-file.sh /tmp/


### PR DESCRIPTION
At this point it's very easy for our repos to go out of sync with the toolchain supplied by our image and silently recompile different version of Golang. This PR makes sure the local go version is user or an error is shown. We should always update this shared image to the latest so showing the error on mismatch is desirable.

Fixes #43