### PR TITLE
Bump Go images to latest stable versions

### DIFF
--- a/golang/1.21/Dockerfile
+++ b/golang/1.21/Dockerfile
@@ -12,11 +12,11 @@ RUN apt update && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* && \
     case $(arch) in \
-        x86_64) architecture="amd64" checksum="f648d7e8e728aedfebe34a5f29ebdcd03e3f70a17791b333738423db8a3db2fb177d73155b0eaa6522410eebef63dcc3841ca484c729e576459de958994ede74" ;; \
-        aarch64) architecture="arm64" checksum="2bb8fe4aa9a8cb87ce5d8d1978b4d35dd9ccae4369ab7e06b686239f60506e33fe4cd8bced492e4e168f23dc674cca1cddd31b1003efcf66c9f6cbbcb7a11ddf" ;; \
+        x86_64) architecture="amd64" checksum="2a0c0c8aeb25292282fd01fe88e220d91c6b723f94717655567bd318195b70dabe89d04c62078fe0ff27c18e4d0c33b489cf9a5fd06c55f1f12ef74727fcef9c" ;; \
+        aarch64) architecture="arm64" checksum="1f04d9496e7474ba9ad02c0204117ebaafafb1cc2a0f6949990518e599c2a8da38b346ce76b5445075e246382a5f2cc79e5efab2790f89d105a5249284ac2fc7" ;; \
         *) exit 42;; \
     esac && \
-    /tmp/download-file.sh "https://go.dev/dl/go1.21.10.linux-${architecture}.tar.gz" "${checksum}" | tar -C /usr/local -xzf - && \
+    /tmp/download-file.sh "https://go.dev/dl/go1.21.11.linux-${architecture}.tar.gz" "${checksum}" | tar -C /usr/local -xzf - && \
     go install golang.org/x/vuln/cmd/govulncheck@latest && \
     go install github.com/mikefarah/yq/v4@v4.34.1 && \
     go install helm.sh/helm/v3/cmd/helm@1e210a2 && echo "installed helm v3.12.2" && \

--- a/golang/1.22/Dockerfile
+++ b/golang/1.22/Dockerfile
@@ -12,11 +12,11 @@ RUN apt update && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* && \
     case $(arch) in \
-        x86_64) architecture="amd64" checksum="e80a99505145aa2305a88a1ba9ad0ba7ff95a30a527e34c3a22409ec3cab96850eee87631acb91bb6977f02d4c072aa02465356f88f7f625d56bd4371d2c3006" ;; \
-        aarch64) architecture="arm64" checksum="9bf2127647346d9c85b77f320e42c112cee0872694c558a02deaf395bf92d422f71ddda2bab1ff342590d51b9bbb81538c367d49ffbf0a4b1478aa64771997b5" ;; \
+        x86_64) architecture="amd64" checksum="abd28af37e8a5cc6ab6fad942d5392dec5d7539369df54fa884693657899651fad8d82dd25ab0eaf0295ede1fabd8604af9e50f9150d862a913f390a87fbf558" ;; \
+        aarch64) architecture="arm64" checksum="3645e3e526e2abb2f26dd53cdd6095d3c41444d40c681c5b25c03f762ba39816e8d5489a2ee2d3e5de20c7c42560deb4e6d35bc22475fccd1a923e8d6d5905ac" ;; \
         *) exit 42;; \
     esac && \
-    /tmp/download-file.sh "https://go.dev/dl/go1.22.3.linux-${architecture}.tar.gz" "${checksum}" | tar -C /usr/local -xzf - && \
+    /tmp/download-file.sh "https://go.dev/dl/go1.22.4.linux-${architecture}.tar.gz" "${checksum}" | tar -C /usr/local -xzf - && \
     go install golang.org/x/vuln/cmd/govulncheck@latest && \
     go install github.com/mikefarah/yq/v4@v4.34.1 && \
     go install helm.sh/helm/v3/cmd/helm@1e210a2 && echo "installed helm v3.12.2" && \


### PR DESCRIPTION
Bumps Go 1.21 image to 1.21.11, and 1.22 to 1.22.4.

/cc @tnozicka 