### PR TITLE
Disable goproxy and add verbosity to `go install`

### DIFF
--- a/golang/1.22/Dockerfile
+++ b/golang/1.22/Dockerfile
@@ -2,7 +2,8 @@ FROM to-be-replaced-by-local-ref/base:ubi-9.4-minimal
 
 ENV GOPATH=/go \
     GOROOT=/usr/local/go \
-    GOTOOLCHAIN=local
+    GOTOOLCHAIN=local \
+    GOPROXY=direct
 ENV PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin
 
 COPY ./download-file.sh /tmp/

--- a/golang/1.22/Dockerfile
+++ b/golang/1.22/Dockerfile
@@ -19,8 +19,8 @@ RUN microdnf update -y && \
         *) exit 42;; \
     esac && \
     /tmp/download-file.sh "https://go.dev/dl/go1.22.7.linux-${architecture}.tar.gz" "${checksum}" | tar -C /usr/local -xzf - && \
-    go install golang.org/x/vuln/cmd/govulncheck@latest && \
-    go install github.com/mikefarah/yq/v4@v4.44.3 && \
-    go install helm.sh/helm/v3/cmd/helm@1e210a2 && echo "installed helm v3.12.2" && \
+    go install -v golang.org/x/vuln/cmd/govulncheck@latest && \
+    go install -v github.com/mikefarah/yq/v4@v4.44.3 && \
+    go install -v helm.sh/helm/v3/cmd/helm@1e210a2 && echo "installed helm v3.12.2" && \
     mv "$( go env GOPATH )/bin/yq" /usr/local/bin/ && \
     rm -rf /tmp/*

--- a/golang/1.23/Dockerfile
+++ b/golang/1.23/Dockerfile
@@ -2,7 +2,8 @@ FROM to-be-replaced-by-local-ref/base:ubi-9.4-minimal
 
 ENV GOPATH=/go \
     GOROOT=/usr/local/go \
-    GOTOOLCHAIN=local
+    GOTOOLCHAIN=local \
+    GOPROXY=direct
 ENV PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin
 
 COPY ./download-file.sh /tmp/

--- a/golang/1.23/Dockerfile
+++ b/golang/1.23/Dockerfile
@@ -19,8 +19,8 @@ RUN microdnf update -y && \
         *) exit 42;; \
     esac && \
     /tmp/download-file.sh "https://go.dev/dl/go1.23.1.linux-${architecture}.tar.gz" "${checksum}" | tar -C /usr/local -xzf - && \
-    go install golang.org/x/vuln/cmd/govulncheck@latest && \
-    go install github.com/mikefarah/yq/v4@v4.44.3 && \
-    go install helm.sh/helm/v3/cmd/helm@1e210a2 && echo "installed helm v3.12.2" && \
+    go install -v golang.org/x/vuln/cmd/govulncheck@latest && \
+    go install -v github.com/mikefarah/yq/v4@v4.44.3 && \
+    go install -v helm.sh/helm/v3/cmd/helm@1e210a2 && echo "installed helm v3.12.2" && \
     mv "$( go env GOPATH )/bin/yq" /usr/local/bin/ && \
     rm -rf /tmp/*


### PR DESCRIPTION
This PR disables GOPROXY to avoid extra jump and an option for additional failures. It also adds verbosity to `go install` commands so we have a better idea where they get stuck, if at all.

Resolves #60 