### PR TITLE
Add tar to UBI base image so it works with kubectl cp

### DIFF
--- a/base/ubi/9.4-minimal/Dockerfile
+++ b/base/ubi/9.4-minimal/Dockerfile
@@ -4,7 +4,7 @@ SHELL ["/usr/bin/bash", "-euExo", "pipefail", "-O", "inherit_errexit", "-c"]
 
 # Install a minimal subset of packages that *every* runtime image needs.
 RUN microdnf update -y && \
-    microdnf install -y jq && \
+    microdnf install -y jq tar && \
     microdnf clean all && \
     rm -rf /var/cache/dnf/* && \
     curl -L https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/RPM-GPG-KEY-AlmaLinux-9 -o /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux


### PR DESCRIPTION
`kubectl cp` requires `tar` binary in the target image so we need to include it in the UBI base image used as a runtime.

Resolves #66