### PR TITLE
Update python version to 3.12 in poetry 1.8 image

### DIFF
--- a/poetry/1.8/Dockerfile
+++ b/poetry/1.8/Dockerfile
@@ -2,7 +2,7 @@ FROM to-be-replaced-by-local-ref/base:ubi-9.4-minimal
 
 RUN set -euExo pipefail && shopt -s inherit_errexit && \
     microdnf update -y && \
-    microdnf install -y make python3.9 git && \
+    microdnf install -y make python3.12 git && \
     microdnf clean all && \
     rm -rf /var/cache/dnf/* && \
     poetry_version=1.8.3 && \
@@ -10,7 +10,7 @@ RUN set -euExo pipefail && shopt -s inherit_errexit && \
     poetry_installer="$( mktemp )" && \
     curl --fail --retry 5 --retry-all-errors -L "https://raw.githubusercontent.com/python-poetry/install.python-poetry.org/fcd759d6feb9142736a19f8a753be975a120be87/install-poetry.py" -o "${poetry_installer}" && \
     sha512sum -c <( echo "${installer_checksum}  ${poetry_installer}" ) && \
-    python3 "${poetry_installer}" --version "${poetry_version}" -y && \
+    python3.12 "${poetry_installer}" --version "${poetry_version}" -y && \
     rm "${poetry_installer}" && \
     ln -s ~/.local/bin/poetry /usr/local/bin/poetry && \
     poetry --version


### PR DESCRIPTION
This PR updates python version used in poetry-1.8 image to 3.12.

Required by https://github.com/scylladb/scylla-operator/pull/2132.

```
The currently activated Python version 3.9.18 is not supported by the project (^3.10).
Trying to find and use a compatible version. 
```

/kind feature
/priority important-soon
/cc zimnx