### PR TITLE
Downgrade python version to 3.11 in poetry 1.8 image

### DIFF
--- a/poetry/1.8/Dockerfile
+++ b/poetry/1.8/Dockerfile
@@ -2,7 +2,7 @@ FROM to-be-replaced-by-local-ref/base:ubi-9.4-minimal
 
 RUN set -euExo pipefail && shopt -s inherit_errexit && \
     microdnf update -y && \
-    microdnf install -y make python3.12 git && \
+    microdnf install -y make python3.11 git && \
     microdnf clean all && \
     rm -rf /var/cache/dnf/* && \
     poetry_version=1.8.3 && \
@@ -10,7 +10,7 @@ RUN set -euExo pipefail && shopt -s inherit_errexit && \
     poetry_installer="$( mktemp )" && \
     curl --fail --retry 5 --retry-all-errors -L "https://raw.githubusercontent.com/python-poetry/install.python-poetry.org/fcd759d6feb9142736a19f8a753be975a120be87/install-poetry.py" -o "${poetry_installer}" && \
     sha512sum -c <( echo "${installer_checksum}  ${poetry_installer}" ) && \
-    python3.12 "${poetry_installer}" --version "${poetry_version}" -y && \
+    python3.11 "${poetry_installer}" --version "${poetry_version}" -y && \
     rm "${poetry_installer}" && \
     ln -s ~/.local/bin/poetry /usr/local/bin/poetry && \
     poetry --version


### PR DESCRIPTION
`distutils` package was removed from python 3.12 https://peps.python.org/pep-0632/, which causes jobs building docs in scylla-operator master to fail after poetry image update to 1.8. This PR downgrades python version used in poetry-1.8 image to 3.11.

/kind bug
/priority critical-urgent
/cc zimnx