### PR TITLE
Add findutils needed by node tuning

### DIFF
--- a/base/ubi/9.4-minimal/Dockerfile
+++ b/base/ubi/9.4-minimal/Dockerfile
@@ -4,7 +4,7 @@ SHELL ["/usr/bin/bash", "-euExo", "pipefail", "-O", "inherit_errexit", "-c"]
 
 # Install a minimal subset of packages that *every* runtime image needs.
 RUN microdnf update -y && \
-    microdnf install -y jq tar && \
+    microdnf install -y jq tar findutils && \
     microdnf clean all && \
     rm -rf /var/cache/dnf/* && \
     curl -L https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/RPM-GPG-KEY-AlmaLinux-9 -o /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux


### PR DESCRIPTION
This PR adds `find` command into the ubi-9.4 base images that is needed by scylla operator node tuning.

https://gcsweb.scylla-operator.scylladb.com/gcs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/2121/pull-scylla-operator-master-e2e-gke-parallel/1841429706876915712/artifacts/must-gather/0/namespaces/scylla-operator-node-tuning/pods/cluster-node-setup-5wg9x/scylla-node-config.previous

```
2024-10-02T11:01:32.380604359Z ++ mktemp -d
2024-10-02T11:01:32.381935808Z + cd /tmp/tmp.7CEiQTLv9l
2024-10-02T11:01:32.382202238Z ++ find /host -mindepth 1 -maxdepth 1 -type d -printf '%f\n'
2024-10-02T11:01:32.382265938Z /usr/bin/bash: line 8: find: command not found
2024-10-02T11:01:32.382660458Z ++ find /host -mindepth 1 -maxdepth 1 -type f -printf '%f\n'
2024-10-02T11:01:32.382680518Z /usr/bin/bash: line 13: find: command not found
2024-10-02T11:01:32.382880448Z + find /host -mindepth 1 -maxdepth 1 -type l -exec cp -P '{}' ./ ';'
2024-10-02T11:01:32.383062218Z /usr/bin/bash: line 18: find: command not found
```