### PR TITLE
Add mount command needed by scylla-operator node tuning

### DIFF
--- a/base/ubi/9.4-minimal/Dockerfile
+++ b/base/ubi/9.4-minimal/Dockerfile
@@ -4,7 +4,7 @@ SHELL ["/usr/bin/bash", "-euExo", "pipefail", "-O", "inherit_errexit", "-c"]
 
 # Install a minimal subset of packages that *every* runtime image needs.
 RUN microdnf update -y && \
-    microdnf install -y jq tar findutils && \
+    microdnf install -y jq tar findutils util-linux-core && \
     microdnf clean all && \
     rm -rf /var/cache/dnf/* && \
     curl -L https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/RPM-GPG-KEY-AlmaLinux-9 -o /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux


### PR DESCRIPTION
This PR adds `mount` command into our base image that's used by scylla-operator node tuning.

```
2024-10-03T15:02:56.482957195Z ++ mktemp -d
2024-10-03T15:02:56.484417583Z + cd /tmp/tmp.x1iSU76bK0
2024-10-03T15:02:56.484703683Z ++ find /host -mindepth 1 -maxdepth 1 -type d -printf '%f\n'
2024-10-03T15:02:56.485646042Z + for d in $( find /host -mindepth 1 -maxdepth 1 -type d -printf '%f\n' )
2024-10-03T15:02:56.485650702Z + mkdir -p ./home
2024-10-03T15:02:56.486823440Z + mount --rbind /host/home ./home
2024-10-03T15:02:56.487044450Z /usr/bin/bash: line 10: mount: command not found
```
https://gcsweb.scylla-operator.scylladb.com/gcs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/2121/pull-scylla-operator-master-e2e-gke-parallel/1841852773419716608/artifacts/must-gather/0/namespaces/scylla-operator-node-tuning/pods/cluster-node-setup-5q6tc/scylla-node-config.previous