### PR TITLE
Add netcat to node-setup helper image

### DIFF
--- a/node-setup/Dockerfile
+++ b/node-setup/Dockerfile
@@ -1,6 +1,6 @@
 FROM to-be-replaced-by-local-ref/base:ubi-9.4-minimal
 
 RUN microdnf update -y && \
-    microdnf install -y xfsprogs mdadm --nodocs --enablerepo almalinux-base-9 && \
+    microdnf install -y xfsprogs mdadm nc --nodocs --enablerepo almalinux-base-9 && \
     microdnf clean all && \
     rm -rf /var/cache/dnf/*


### PR DESCRIPTION
Image is used only in Operator E2E tests.

Required by https://github.com/scylladb/scylla-operator/pull/2175