### PR TITLE
Add diffutils package to golang images

### DIFF
--- a/golang/1.23/Dockerfile
+++ b/golang/1.23/Dockerfile
@@ -12,7 +12,7 @@ COPY *.sum /tmp/
 
 RUN set -euExo pipefail && shopt -s inherit_errexit && \
     microdnf update -y && \
-    microdnf install -y git make tar gzip gcc g++ findutils && \
+    microdnf install -y git make tar gzip gcc g++ findutils diffutils && \
     microdnf install -y dbus-x11 --enablerepo=almalinux-appstream-9 && \
     microdnf clean all && \
     rm -rf /var/cache/dnf/* && \

--- a/golang/1.24/Dockerfile
+++ b/golang/1.24/Dockerfile
@@ -12,7 +12,7 @@ COPY *.sum /tmp/
 
 RUN set -euExo pipefail && shopt -s inherit_errexit && \
     microdnf update -y && \
-    microdnf install -y git make tar gzip gcc g++ findutils && \
+    microdnf install -y git make tar gzip gcc g++ findutils diffutils && \
     microdnf install -y dbus-x11 --enablerepo=almalinux-appstream-9 && \
     microdnf clean all && \
     rm -rf /var/cache/dnf/* && \


### PR DESCRIPTION
`diff` command used by our Makefile was removed in recent UBI's. This installs it explicitly.

```
$ podman run -ti --pull=always --entrypoint=/bin/bash --rm quay.io/scylladb/scylla-operator-images:golang-1.24
[root@c59ef1b1755a /]# diff
bash: diff: command not found

$ podman run -ti --pull=always --entrypoint=/bin/bash --rm quay.io/scylladb/scylla-operator-images:golang-1.23                                                            
[root@ecf73436f209 /]# diff
bash: diff: command not found

```

https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/2524/pull-scylla-operator-master-verify-deps/1904523847495847936