### PR TITLE
Add procps-ng to node-setup image

### DIFF
--- a/node-setup/Dockerfile
+++ b/node-setup/Dockerfile
@@ -1,6 +1,6 @@
 FROM to-be-replaced-by-local-ref/base:ubi-9.4-minimal
 
 RUN microdnf update -y && \
-    microdnf install -y xfsprogs mdadm nc --nodocs --enablerepo almalinux-base-9 && \
+    microdnf install -y xfsprogs mdadm nc procps-ng --nodocs --enablerepo almalinux-base-9 && \
     microdnf clean all && \
     rm -rf /var/cache/dnf/*


### PR DESCRIPTION
Operator e2e's will require `pidof` which currently is missing.

/cc czeslavo 