### PR TITLE
Add file to golang-1.24 image

### DIFF
--- a/golang/1.24/Dockerfile
+++ b/golang/1.24/Dockerfile
@@ -12,7 +12,7 @@ COPY /checksums/*.sum /checksums/
 
 RUN set -euExo pipefail && shopt -s inherit_errexit && \
     microdnf update -y && \
-    microdnf install -y git make tar gzip gcc g++ findutils diffutils && \
+    microdnf install -y git make tar gzip gcc g++ findutils diffutils file && \
     microdnf install -y dbus-x11 --enablerepo=almalinux-appstream-9 && \
     microdnf clean all && \
     rm -rf /var/cache/dnf/* && \


### PR DESCRIPTION
Turns out we don't have `file` in `golang-1.24` image:
https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/2885/pull-scylla-operator-master-verify/1956013190445797376#1:build-log.txt%3A313

/cc czeslavo