### PR TITLE
Raise subuids and subgids in kube-tools image

### DIFF
--- a/kube-tools/latest/Dockerfile
+++ b/kube-tools/latest/Dockerfile
@@ -6,6 +6,9 @@ ENV GOPATH=/go \
 COPY ./download-file.sh /tmp/
 
 RUN set -euExo pipefail && shopt -s inherit_errexit && \
+    # https://docs.podman.io/en/latest/markdown/podman.1.html#rootless-mode
+    usermod --add-subuids 10000-75535 podman && \
+    usermod --add-subgids 10000-75535 podman && \
     dnf install -y rsync git make tar gzip skopeo jq procps-ng && \
     dnf clean all && \
     case $(arch) in \


### PR DESCRIPTION
It's required in order to use podman in rootless mode.

Attempt to fix:
https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/2885/pull-scylla-operator-master-olm-catalog/1957425576847347712

/cc czeslavo