### PR TITLE
feat(buildah): register QEMU binfmt handlers for cross-arch builds

### DIFF
--- a/buildah/latest/Dockerfile
+++ b/buildah/latest/Dockerfile
@@ -4,3 +4,7 @@ RUN set -euExo pipefail && shopt -s inherit_errexit && \
     dnf install -y git && \
     dnf clean all && \
     git config --system --add safe.directory '*'
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/buildah/latest/entrypoint.sh
+++ b/buildah/latest/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s inherit_errexit
+
+# Register QEMU binfmt_misc handlers to enable cross-architecture builds
+# (e.g. building linux/arm64 images on an amd64 host).
+#
+# The base image (quay.io/buildah/stable) already ships with:
+# - qemu-user-static binaries (e.g. /usr/bin/qemu-aarch64-static)
+# - binfmt.d configuration files (/usr/lib/binfmt.d/qemu-*.conf)
+# - systemd-binfmt tool (part of systemd-udev)
+#
+# What's missing at container startup is:
+# 1. The binfmt_misc kernel pseudo-filesystem isn't mounted in containers by default.
+# 2. The binfmt handlers from /usr/lib/binfmt.d/ aren't registered until something
+#    reads the conf files and writes them into /proc/sys/fs/binfmt_misc/register.
+#
+# The mount requires --privileged or CAP_SYS_ADMIN. When running without privileges,
+# the mount silently fails and cross-arch builds won't be available, but native-arch
+# builds continue to work normally.
+
+# Mount the binfmt_misc filesystem so that handlers can be registered.
+mount -t binfmt_misc binfmt_misc /proc/sys/fs/binfmt_misc 2>/dev/null || true
+
+# Use systemd-binfmt to register all handlers from /usr/lib/binfmt.d/.
+# It's a no-op when binfmt_misc isn't mounted (non-privileged containers).
+/usr/lib/systemd/systemd-binfmt
+
+exec "$@"


### PR DESCRIPTION
Adds an entrypoint script that enables using `buildah` image for cross-platform builds by:

- mounting binfmt_misc filesystem (ref: https://docs.kernel.org/admin-guide/binfmt-misc.html)
- registering handlers by calling `systemd-binfmt` (ref: https://www.freedesktop.org/software/systemd/man/latest/systemd-binfmt.service.html?__goaway_challenge=meta-refresh&__goaway_id=ac886e2eb49e27e7a4ef8bdacce2e081)

Notes: `systemd-binfmt` and `qemu-user-static` packages are already installed in the base image.

This image was used in test ProwJob running on a amd64 machine: https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/logs/post-scylla-operator-master-images-arm64/2042197731597881344

/cc @mflendrich 