### PR TITLE
feat: add docker image to submit prow jobs for Jenkins

### DIFF
--- a/image-spec.csv
+++ b/image-spec.csv
@@ -8,3 +8,4 @@ context_dir,image_tag,from_tag
 ./node-setup,node-setup,base-ubi-9.7-minimal
 ./uv/0.10,uv-0.10,base-ubi-9.7-minimal
 ./buildah/latest,buildah,
+./jenkins-e2e/latest,jenkins-e2e,

--- a/jenkins-e2e/latest/Dockerfile
+++ b/jenkins-e2e/latest/Dockerfile
@@ -1,0 +1,18 @@
+FROM docker.io/library/golang:1.26 AS builder
+
+RUN go install sigs.k8s.io/prow/cmd/mkpj@latest
+
+RUN curl -fsSL -o /usr/local/bin/kubectl \
+      "https://dl.k8s.io/release/v1.33.0/bin/linux/amd64/kubectl" && \
+    chmod +x /usr/local/bin/kubectl
+
+FROM quay.io/scylladb/scylla-operator-images:base-ubi-9.7-minimal
+
+COPY --from=builder /go/bin/mkpj /usr/local/bin/mkpj
+COPY --from=builder /usr/local/bin/kubectl /usr/local/bin/kubectl
+
+COPY config.yaml /etc/prow/config.yaml
+COPY job.yaml /etc/prow/job.yaml
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/jenkins-e2e/latest/entrypoint.sh
+++ b/jenkins-e2e/latest/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/bash
+set -euEo pipefail
+
+if [[ -z "${SCYLLADB_IMAGE_REF:-}" ]]; then
+  echo "error: SCYLLADB_IMAGE_REF is not set or empty" >&2
+  exit 1
+fi
+
+if [[ -z "${PROWJOB_NAME:-}" ]]; then
+  echo "error: PROWJOB_NAME is not set or empty" >&2
+  exit 1
+fi
+
+tmpfile=$(mktemp)
+trap "rm -f '${tmpfile}'" EXIT
+
+sed "s|__SCYLLADB_IMAGE_REF__|${SCYLLADB_IMAGE_REF}|; s|__PROWJOB_NAME__|${PROWJOB_NAME}|" \
+  /etc/prow/job.yaml > "${tmpfile}"
+
+mkpj \
+  --config-path=/etc/prow/config.yaml \
+  --job-config-path="${tmpfile}" \
+  --job="${PROWJOB_NAME}" \
+| kubectl create -n prow-workspace -f -

--- a/jenkins-e2e/latest/job.yaml
+++ b/jenkins-e2e/latest/job.yaml
@@ -1,0 +1,62 @@
+periodics:
+- name: __PROWJOB_NAME__
+  # Prow requires either periodics or presubmit, postsubmit jobs. This is a hack (only schedule on "February 31").
+  cron: "0 0 31 2 *"
+  decorate: true
+  extra_refs:
+  - org: scylladb
+    repo: scylla-operator
+    base_ref: master
+    path_alias: github.com/scylladb/scylla-operator
+  spec:
+    nodeSelector:
+      pool: kind-workers
+    tolerations:
+    - key: "dedicated"
+      operator: "Equal"
+      value: "kind"
+      effect: "NoSchedule"
+    containers:
+    - name: jenkins-e2e-kind
+      image: quay.io/scylladb/scylla-operator-images:kube-tools
+      imagePullPolicy: IfNotPresent
+      command:
+      - /usr/bin/bash
+      - -euExo
+      - pipefail
+      - -O
+      - inherit_errexit
+      - -O
+      - extglob
+      - -c
+      args:
+      - |
+        function resolve-image {
+          (
+            set -euEo pipefail
+            local digest
+            digest=$( skopeo inspect --raw docker://"${1}" | skopeo manifest-digest /dev/stdin )
+            echo "${1}@${digest}"
+          )
+        }
+
+        SO_IMAGE="$( resolve-image docker.io/scylladb/scylla-operator:latest )"
+        SO_IMAGE="${SO_IMAGE/:*([^:\/])@/@}"
+        export SO_IMAGE
+
+        # Disable pids limit to allow high parallelism in tests.
+        sed -i '/\[containers\]/a pids_limit = 0' /etc/containers/containers.conf
+
+        make test-e2e-kind
+      env:
+      - name: SCYLLADB_IMAGE_REF
+        value: __SCYLLADB_IMAGE_REF__
+      resources:
+        requests:
+          cpu: 6
+          memory: 12Gi
+        limits:
+          cpu: 6
+          memory: 12Gi
+      securityContext:
+        privileged: true


### PR DESCRIPTION
This PR adds a Docker image to enable Jenkins pipelines to create Prow jobs with custom ScyllaDB builds.
Also add minimal necessary configuration files (to avoid cross-referencing scylla-operator-release).

This is a temporary solution (until Prow is decommissioned - after which these files can be dropped and the logic in Jenkins pipeline is also altered)